### PR TITLE
Omit a `target` when none is provided in a transition

### DIFF
--- a/src/core/compiler_xstate.c
+++ b/src/core/compiler_xstate.c
@@ -516,8 +516,11 @@ static void enter_transition(PrintState* state, JSBuilder* jsb, Node* node) {
 
   if(use_object_notation) {
     js_builder_start_object(jsb);
-    js_builder_start_prop(jsb, "target");
-    js_builder_add_string(jsb, transition_node->dest);
+
+    if(transition_node->dest != NULL) {
+      js_builder_start_prop(jsb, "target");
+      js_builder_add_string(jsb, transition_node->dest);
+    }
 
     if(has_guard) {
       js_builder_start_prop(jsb, "cond");

--- a/src/core/parser.c
+++ b/src/core/parser.c
@@ -652,19 +652,17 @@ static int consume_transition(State* state) {
         free(identifier);
         break;
       }
+      default: {
+        if(state_has_guard(state, identifier)) {
+          node_transition_add_guard(transition_node, identifier);
+        } else if(state_has_action(state, identifier)) {
+          node_transition_add_action(transition_node, identifier);
+        } else {
+          transition_node->dest = identifier;
+        }
+        break;
+      }
     }
-
-    if(state_has_guard(state, identifier)) {
-      node_transition_add_guard(transition_node, identifier);
-    } else if(state_has_action(state, identifier)) {
-      node_transition_add_action(transition_node, identifier);
-    } else {
-      transition_node->dest = identifier;
-    }
-  }
-
-  if(transition_node->dest == NULL) {
-    transition_node->dest = state_node->name;
   }
 
   end: {

--- a/test/demos/playground.html
+++ b/test/demos/playground.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+<title>Test environment</title>
+
+<script type="module">
+
+import { createMachine, assign } from 'https://cdn.skypack.dev/xstate';
+import { interpret } from 'https://cdn.skypack.dev/xstate';
+
+const TestMachine = createMachine({
+  initial: 'initial',
+  states: {
+    initial: {
+      on: {
+        test: {
+          //target: 'initial',
+          actions: [
+            assign({
+              someValue: (context, event) => event.data
+            })
+          ]
+        }
+      }
+    }
+  }
+});
+
+const service = interpret(TestMachine).onTransition(state => {
+  console.log('State', state.value);
+});
+
+service.start();
+
+service.send('test');
+
+service.stop();
+</script>

--- a/test/snapshots/guards_and_actions/expected.js
+++ b/test/snapshots/guards_and_actions/expected.js
@@ -7,12 +7,10 @@ export default createMachine({
     active: {
       on: {
         inc: {
-          target: 'active',
           cond: 'isNotMax',
           actions: ['increment']
         },
         dec: {
-          target: 'active',
           cond: 'isNotMin',
           actions: ['decrement']
         }

--- a/test/snapshots/no_target/expected.js
+++ b/test/snapshots/no_target/expected.js
@@ -1,0 +1,18 @@
+import { createMachine, assign } from 'xstate';
+
+export default createMachine({
+  initial: 'initial',
+  states: {
+    initial: {
+      on: {
+        test: {
+          actions: [
+            assign({
+              someValue: (context, event) => event.data
+            })
+          ]
+        }
+      }
+    }
+  }
+});

--- a/test/snapshots/no_target/input.lucy
+++ b/test/snapshots/no_target/input.lucy
@@ -1,0 +1,3 @@
+initial state initial {
+  test => assign(someValue)
+}


### PR DESCRIPTION
Fixes #23