### PR TITLE
Rename binary to lucyc

### DIFF
--- a/.github/workflows/lucy.yml
+++ b/.github/workflows/lucy.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: make test
       run: |
-        make bin/lc
+        make bin/lucyc
         make dist/liblucy-debug-node.mjs
         make dist/liblucy-release-node.mjs
         make test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,8 @@ jobs:
     - uses: actions/checkout@v1
     - name: build
       run: |
-        make bin/lc
-        cd bin && tar -zcvf ../${{ matrix.name }}.tar.gz lc && cd -
+        make bin/lucyc
+        cd bin && tar -zcvf ../${{ matrix.name }}.tar.gz lucyc && cd -
     - uses: ncipollo/release-action@v1
       with:
         allowUpdates: true

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BIN_C_FILES=$(shell find src/bin -type f -name "*.c")
 WASM_C_FILES=$(shell find src/wasm -type f -name "*.c")
 
 all: dist/liblucy-debug-node.mjs dist/liblucy-debug-browser.mjs \
-	dist/liblucy-release-node.mjs dist/liblucy-release-browser.mjs bin/lc
+	dist/liblucy-release-node.mjs dist/liblucy-release-browser.mjs bin/lucyc
 .PHONY: all
 
 build:
@@ -52,7 +52,7 @@ dist/liblucy-release-node.mjs: dist build/liblucy-release.mjs dist/liblucy-relea
 dist/liblucy-release-browser.mjs: dist build/liblucy-release.mjs dist/liblucy-release.wasm
 	cp build/liblucy-release.mjs $@
 
-bin/lc: $(SRC_FILES)
+bin/lucyc: $(SRC_FILES)
 	@mkdir -p bin
 	$(CC) ${BIN_C_FILES} $(CORE_C_FILES) -o $@ \
 		-DVERSION=\"$(VERSION)\" \
@@ -62,7 +62,7 @@ clean:
 	@rm -f dist/liblucy-debug-browser.mjs dist/liblucy-debug-node.mjs \
 		dist/liblucy-debug.wasm dist/liblucy-release-browser.mjs \
 		dist/liblucy-release-node.mjs dist/liblucy-release.wasm
-	@rm -f bin/lc
+	@rm -f bin/lucyc
 	@rmdir dist bin 2> /dev/null
 .PHONY: clean
 
@@ -72,11 +72,11 @@ test-native:
 .PHONY: test-native
 
 test-wasm:
-	@LC=scripts/lucyc.mjs scripts/test_snapshots
+	@LUCYC=scripts/lucyc.mjs scripts/test_snapshots
 .PHONY: test-wasm
 
 test-wasm-release:
-	@LC=scripts/lucyc.mjs NODE_ENV=production scripts/test_snapshots
+	@LUCYC=scripts/lucyc.mjs NODE_ENV=production scripts/test_snapshots
 .PHONY: test-wasm-release
 
 test: test-native test-wasm test-wasm-release

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # liblucy
 
-__liblucy__ is the core piece of [Lucy](https://lucylang.org/) the DSL. It contains the core compiler that is compiled to wasm for usage in JavaScript environments such as Node.js. It also includes the CLI compiler, `lc`.
+__liblucy__ is the core piece of [Lucy](https://lucylang.org/) the DSL. It contains the core compiler that is compiled to wasm for usage in JavaScript environments such as Node.js. It also includes the CLI compiler, `lucyc`.
 
 ## Contributing
 

--- a/scripts/test_snapshots
+++ b/scripts/test_snapshots
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-LC="${LC:-bin/lc}"
+LUCYC="${LUCYC:-bin/lucyc}"
 NODE_ENV="${NODE_ENV:-development}"
 ret=0
 upd=0
@@ -43,7 +43,7 @@ run_test() {
     local output="${d}expected.js"
   fi
 
-  NODE_ENV=$NODE_ENV $LC $input >> $tmp 2>&1
+  NODE_ENV=$NODE_ENV $LUCYC $input >> $tmp 2>&1
 
   if [ "$upd" -eq 1 ]; then
     mv $tmp $output

--- a/scripts/test_unit
+++ b/scripts/test_unit
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-LC="${LC:-bin/lc}"
+LUCYC="${LUCYC:-bin/lucyc}"
 ret=0
 
 run_test() {
@@ -12,7 +12,7 @@ run_test() {
   fi
 
   local test="${d}test.sh"
-  LC="$LC" $test
+  LUCYC="$LUCYC" $test
   local r=$?
 
   if [ $ret -eq 0 ]; then

--- a/test/unit/out-dir/test.sh
+++ b/test/unit/out-dir/test.sh
@@ -9,7 +9,7 @@ srcdir="$dir/src"
 rm -rf $outdir
 
 # Run compiler
-$LC --out-dir $outdir $srcdir
+$LUCYC --out-dir $outdir $srcdir
 
 # Test to see if expected files exist.
 if [ ! -f "$outdir/machine.js" ]; then

--- a/test/unit/remote_imports/test.sh
+++ b/test/unit/remote_imports/test.sh
@@ -10,7 +10,7 @@ expected="$dir/expected.js"
 tmp=$(mktemp)
 
 # Run compiler
-$LC --remote-imports --out-file $tmp $input
+$LUCYC --remote-imports --out-file $tmp $input
 
 d=$(diff $expected $tmp | colordiff)
 


### PR DESCRIPTION
As pointed out, `lc` is used by the Mono compiler. Want to avoid having
people need to alias the binary, so going to rename to `lucyc`.